### PR TITLE
Redmine Issue TrashプラグインのReadMe追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redmine Issue Trash plugin
 
-削除操作を行ったチケットを復元可能とするためのプラグインです。
+誤操作などで削除してしまったチケットを復元できるようにするプラグインです。
 
 ## Getting started
 

--- a/init.rb
+++ b/init.rb
@@ -2,6 +2,9 @@
 
 Redmine::Plugin.register :redmine_issue_trash do
   name 'Redmine Issue Trash'
+  author 'Agileware Inc.'
+  description 'This is a plugin for Redmine'
+  author_url 'http://agileware.jp'
   version '1.0.0'
 
   activity_provider :trashed_issues


### PR DESCRIPTION
* githubプラグインのreadmeをベースに作成
    * githubプラグインのreadmeから「Install the plugin」と「License」を流用
    * Issue Templatesプラグインのreadmeから「Uninstall」(冒頭部分のみ)と「Description and usage info」(形式のみ)を流用
    * 概要を追加（日本語）
* ついでにinit.rbのバージョン情報を修正

（備考）
Description and usage infoのリンク先（使い方のwiki）は作成中
