### PR TITLE
Fix to show image attachments of trashed journals

### DIFF
--- a/app/models/trashed_issue.rb
+++ b/app/models/trashed_issue.rb
@@ -76,7 +76,7 @@ class TrashedIssue < ActiveRecord::Base
   end
 
   def rebuild
-    IssueWrapper.new(attributes_json).tap do |i|
+    IssueWrapper.new(attributes_json, self).tap do |i|
       i.parent_id = nil if i.parent.blank?
       i.attachments = attachments.map do |attachment|
         attachment.copy(container: i)

--- a/app/models/trashed_issue/issue_wrapper.rb
+++ b/app/models/trashed_issue/issue_wrapper.rb
@@ -8,7 +8,7 @@ class TrashedIssue
       delegate :primary_key, :polymorphic_name, to: Issue
     end
 
-    def initialize(attributes)
+    def initialize(attributes, trashed_issue)
       super(Issue.new(attributes.except(
                         'custom_field_values',
                         'child_ids',
@@ -22,7 +22,7 @@ class TrashedIssue
       self.watcher_users = User.where(id: attributes['watcher_user_ids'])
       @child_ids = attributes['child_ids'] || []
       @relations = (attributes['relations'] || []).map { |attr| IssueRelation.new(attr) }
-      build_jornals(attributes)
+      build_jornals(attributes, trashed_issue)
     end
 
     def tracker
@@ -56,7 +56,7 @@ class TrashedIssue
 
     private
 
-    def build_jornals(attributes)
+    def build_jornals(attributes, trashed_issue)
       return if attributes['journals'].blank?
 
       self.journals = attributes['journals'].map do |journal_attributes|
@@ -81,6 +81,10 @@ class TrashedIssue
                 true
               end
             end
+          end
+
+          define_method :attachments do
+            trashed_issue.attachments
           end
         end
       end

--- a/app/models/trashed_issue/issue_wrapper.rb
+++ b/app/models/trashed_issue/issue_wrapper.rb
@@ -83,8 +83,12 @@ class TrashedIssue
             end
           end
 
-          define_method :attachments do
-            trashed_issue.attachments
+          define_method :journalized do |*args|
+            super(*args).tap do |issue|
+              issue.define_singleton_method :attachments do
+                trashed_issue.attachments
+              end
+            end
           end
         end
       end

--- a/lib/redmine_issue_trash/issue_patch.rb
+++ b/lib/redmine_issue_trash/issue_patch.rb
@@ -19,6 +19,7 @@ module RedmineIssueTrash
 
         def trash!
           init_journal(User.current, I18n.t(:notes_issue_trashed))
+          current_journal.notify = false
           save!(validate: false)
           TrashedIssue.copy_from!(self)
         end

--- a/spec/models/trashed_issue/issue_wrapper_spec.rb
+++ b/spec/models/trashed_issue/issue_wrapper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TrashedIssue::IssueWrapper, type: :model do
 
     it 'accesses attachments of the trashed issue' do
       expect(trashed_issue).to receive(:attachments)
-      wrapped_issue.journals.first.attachments
+      wrapped_issue.journals.first.journalized.attachments
     end
   end
 end

--- a/spec/models/trashed_issue/issue_wrapper_spec.rb
+++ b/spec/models/trashed_issue/issue_wrapper_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../rails_helper', __dir__)
+
+RSpec.describe TrashedIssue::IssueWrapper, type: :model do
+  before :each do
+    allow(User).to receive(:current).and_return create(:user)
+  end
+
+  describe 'attachments of journals' do
+    let(:wrapped_issue) { TrashedIssue::IssueWrapper.new(trashed_issue.attributes_json, trashed_issue) }
+    let(:trashed_issue) do
+      create(:issue).destroy
+      TrashedIssue.first
+    end
+
+    it 'accesses attachments of the trashed issue' do
+      expect(trashed_issue).to receive(:attachments)
+      wrapped_issue.journals.first.attachments
+    end
+  end
+end


### PR DESCRIPTION
Fix the following problem:
- When trashed journals have image attatchments, `parse_inline_attachments` helper fails in trashed_issues#show.