### PR TITLE
add reorder to provider proc

### DIFF
--- a/app/models/trashed_issue.rb
+++ b/app/models/trashed_issue.rb
@@ -18,7 +18,7 @@ class TrashedIssue < ActiveRecord::Base
                 type: ->(_) { 'del' } # for del-icon
   acts_as_activity_provider scope: -> { joins(:project) }.tap { |p|
                                      # support proc for old Redmine
-                                     %w[where visible].each do |name|
+                                     %w[where visible reorder].each do |name|
                                        p.define_singleton_method name do |*args|
                                          call.public_send(name, *args)
                                        end


### PR DESCRIPTION
When a request is ATOM format, Redmine4.1.3 or later always calls `Redmine::Activity::Fetcher#events` with the `limit` option. So the provider scope must renpond to `reorder` method.

https://github.com/redmine/redmine/blob/d1b7905ca9af8075542dad8c0fd671c6c82fd32f/app/controllers/activities_controller.rb#L59-L60
https://github.com/redmine/redmine/blob/d1b7905ca9af8075542dad8c0fd671c6c82fd32f/lib/plugins/acts_as_activity_provider/lib/acts_as_activity_provider.rb#L69-L72