### PR TITLE
fix: Display journals in creation order

### DIFF
--- a/app/controllers/trashed_issues_controller.rb
+++ b/app/controllers/trashed_issues_controller.rb
@@ -14,7 +14,10 @@ class TrashedIssuesController < ApplicationController
   def show
     @issue = @trashed.rebuild
     @relations = @issue.relations
-    @journals = sorted_journals_with_index(@issue.journals)
+    @journals = @issue.journals.sort_by(&:created_on)
+    @journals.each.with_index(1) do |journal, indice|
+      journal.indice = indice
+    end
   end
 
   private

--- a/app/controllers/trashed_issues_controller.rb
+++ b/app/controllers/trashed_issues_controller.rb
@@ -14,13 +14,18 @@ class TrashedIssuesController < ApplicationController
   def show
     @issue = @trashed.rebuild
     @relations = @issue.relations
-    @journals = @issue.journals
-    @journals.each.with_index(1) do |journal, indice|
-      journal.indice = indice
-    end
+    @journals = sorted_journals_with_index(@issue.journals)
   end
 
   private
+
+  def sorted_journals_with_index(journals)
+    sorted_journals = journals.sort_by(&:created_on)
+    sorted_journals.each.with_index(1) do |journal, indice|
+      journal.indice = indice
+    end
+    sorted_journals
+  end
 
   def set_trashed_issue
     @trashed = TrashedIssue.find(params[:id])

--- a/app/controllers/trashed_issues_controller.rb
+++ b/app/controllers/trashed_issues_controller.rb
@@ -22,14 +22,6 @@ class TrashedIssuesController < ApplicationController
 
   private
 
-  def sorted_journals_with_index(journals)
-    sorted_journals = journals.sort_by(&:created_on)
-    sorted_journals.each.with_index(1) do |journal, indice|
-      journal.indice = indice
-    end
-    sorted_journals
-  end
-
   def set_trashed_issue
     @trashed = TrashedIssue.find(params[:id])
   end


### PR DESCRIPTION
- The history was not in chronological order.
- `Issue#journals` are not sorted.
    - They are sorted at the time of display. See: https://github.com/redmine/redmine/blob/5.1.3/app/models/issue.rb#L914
- Since trashed `issue#journals` are not persisted, `reorder` cannot be used. Therefore, the `sort_by` method was used to sort them.