### PR TITLE
【Redmine6.0】活動タブでファイルが添付されている削除済みチケットをクリックすると『Internal error』が発生する(Bug #92562)

### DIFF
--- a/app/models/trashed_issue/issue_wrapper.rb
+++ b/app/models/trashed_issue/issue_wrapper.rb
@@ -5,7 +5,13 @@ class TrashedIssue
     attr_reader :child_ids, :relations
 
     class << self
-      delegate :primary_key, :polymorphic_name, to: Issue
+      METHODS = [:primary_key, :polymorphic_name]
+
+      [:has_query_constraints?, :composite_primary_key?].each do |method|
+        METHODS << method if Alm.redmine_version_higher_than?('5.1')
+      end
+
+      delegate *METHODS, to: Issue
     end
 
     def initialize(attributes, trashed_issue)

--- a/app/models/trashed_issue/issue_wrapper.rb
+++ b/app/models/trashed_issue/issue_wrapper.rb
@@ -5,13 +5,7 @@ class TrashedIssue
     attr_reader :child_ids, :relations
 
     class << self
-      METHODS = [:primary_key, :polymorphic_name]
-
-      [:has_query_constraints?, :composite_primary_key?].each do |method|
-        METHODS << method if Alm.redmine_version_higher_than?('5.1')
-      end
-
-      delegate *METHODS, to: Issue
+      delegate :primary_key, :polymorphic_name, :has_query_constraints?, :composite_primary_key?, to: Issue
     end
 
     def initialize(attributes, trashed_issue)


### PR DESCRIPTION
# 現象
- ファイル添付が行われたチケットを削除した後、「活動タブ」から削除された該当チケットを開こうとすると `internal Error` が発生する。

# 原因および対応内容
- Redmine 6 以降の場合は rails 7 で導入された、`has_query_constraints?`, および `composite_primary_key?` メソッドの考慮が必要だった。
- Redmine6以上の場合は、上記メソッドも `delegate` 対象に追記するようにしました。

# イメージ
![image](https://github.com/user-attachments/assets/2e75cd20-4b15-402b-aabb-97566d93f69c)
- 右上に「復元」とあるので、削除済みチケットである。
- 削除済みチケットで、ファイルありのチケットが確認できた。