### PR TITLE
【Redmine6.0】ファイルCFが設定されているチケットを削除→復元すると、ファイルCFが消えている

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -20,4 +20,5 @@ Rails.application.config.after_initialize do
   Project.include RedmineIssueTrash::ProjectPatch::Include
   Redmine::FieldFormat::RecordList.prepend RedmineIssueTrash::RecordListPatch::Prepend
   Redmine::FieldFormat::AttachmentFormat.prepend RedmineIssueTrash::AttachmentFormatPatch::Prepend
+  Redmine::Acts::Customizable::InstanceMethods.prepend RedmineIssueTrash::CustomizablePatch::Prepend
 end

--- a/lib/redmine_issue_trash/customizable_patch.rb
+++ b/lib/redmine_issue_trash/customizable_patch.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RedmineIssueTrash
+  module CustomizablePatch
+    module Prepend
+      def destroy_custom_value_attachments
+        # no-op
+      end
+    end
+  end
+end
+

--- a/lib/tasks/clear.rake
+++ b/lib/tasks/clear.rake
@@ -4,6 +4,19 @@ namespace :redmine_issue_trash do
   task clear: :environment do
     days = ENV['days'].presence&.to_i || 30
 
-    TrashedIssue.where('created_at <= ?', days.days.ago).destroy_all
+    trashed_issues = TrashedIssue.where('created_at <= ?', days.days.ago)
+    return unless trashed_issues
+
+    ActiveRecord::Base.transaction do
+      attachment_ids = trashed_issues.map do |trashed|
+        trashed.rebuild.custom_field_values.map do |cfv|
+          next unless cfv.custom_field.field_format == 'attachment'
+          cfv.value
+        end
+      end.flatten.compact.uniq
+      Attachment.where(id: attachment_ids).delete_all if attachment_ids
+
+      trashed_issues.destroy_all
+    end
   end
 end


### PR DESCRIPTION
# 現象
・チケットにファイルタイプのカスタムフィールド（CF）が設定されている
・上記カスタムフィールドにファイルがセットされている
・上記チケットを削除（ゴミ箱へ移動）した後、「復活」させる
・この時、カスタムフィールドにセットしたファイルがチケットから確認できない（消えている）

# 原因
・Redmine のバグでカスタムフィールド等にセットされた添付ファイルが、チケットを削除しても残ってしまうケースがあった模様
・上記がRedmine6で対応されたため、本プラグイン導入時でもチケット削除（ゴミ箱へ移動）の場合でもカスタムフィールドのファイルが同様に削除されてしまっていた

# 対応
・チケット削除時にファイルを削除しないように修正（いったん以前と同様の動き）
・ただし、ゴミ箱のチケット削除時には削除させる必要があるため、削除用タスクで関連ファイルを削除するよう対応