### PR TITLE
Fix ActiveRecord::CheckViolation on MariaDB/MySQL for attributes_json

### DIFF
--- a/app/models/trashed_issue.rb
+++ b/app/models/trashed_issue.rb
@@ -41,12 +41,20 @@ class TrashedIssue < defined?(ApplicationRecord) == 'constant' ? ApplicationReco
       where(project: allowed_projects).or(where(project: projects, deleted_by: user))
     end
 
+    def attrs_json_for_copy(issue)
+      if %w[trilogy mysql2].include?(ActiveRecord::Base.connection.adapter_name.downcase)
+        attributes(issue).to_json
+      else
+        attributes(issue)
+      end
+    end
+
     def copy_from!(issue)
       return if issue.is_private?
 
       create!(
         project: issue.project,
-        attributes_json: attributes(issue),
+        attributes_json: attrs_json_for_copy(issue),
         deleted_by: User.current
       ).tap do |i|
         i.attachments = issue.attachments.map do |attachment|
@@ -65,7 +73,7 @@ class TrashedIssue < defined?(ApplicationRecord) == 'constant' ? ApplicationReco
     def attributes(issue)
       issue.attributes.except('lock_version', 'lft', 'rgt').merge(
         'custom_field_values' => issue.custom_values.group_by { |cv| cv.custom_field }.map do |cf, values|
-          [cf.id, cf.multiple? ? values.map(&:value) : values.first.value ]
+          [cf.id, cf.multiple? ? values.map(&:value) : values.first.value]
         end.to_h,
         'child_ids' => issue.children.ids,
         'relations' => issue.relations.map(&:attributes),

--- a/spec/models/trashed_issue_spec.rb
+++ b/spec/models/trashed_issue_spec.rb
@@ -262,6 +262,36 @@ RSpec.describe TrashedIssue, type: :model do
         expect(trashed_issue.trashed_custom_values.first.attachments.count).to eq(1)
         expect(trashed_issue.trashed_custom_values.first.attachments.first.digest).to eq(attachment.digest)
       end
+
+      context 'when the adapter is mysql2 or trilogy' do
+        %w[Mysql2 Trilogy].each do |adapter|
+          context "with #{adapter} adapter" do
+            before do
+              connection = instance_double(ActiveRecord::Base.connection.class, adapter_name: adapter)
+              allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+            end
+
+            it 'stores attributes_json as a JSON string' do
+              trashed_issue = TrashedIssue.copy_from!(issue)
+              expect(trashed_issue.attributes_json).to be_a(String)
+              expect(JSON.parse(trashed_issue.attributes_json)).to include('id' => issue.id)
+            end
+          end
+        end
+      end
+
+      context 'when the adapter is not mysql2 or trilogy' do
+        before do
+          connection = instance_double(ActiveRecord::Base.connection.class, adapter_name: 'PostgreSQL')
+          allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+        end
+
+        it 'stores attributes_json as a Hash' do
+          trashed_issue = TrashedIssue.copy_from!(issue)
+          expect(trashed_issue.attributes_json).to be_a(Hash)
+          expect(trashed_issue.attributes_json).to include('id' => issue.id)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## 概要

MariaDB（trilogy / mysql2 アダプター）で Issue を削除しようとすると、`trashed_issues.attributes_json` カラムに `ActiveRecord::CheckViolation` が発生するバグを修正します。

## 原因

MariaDB の `json` カラムは内部的に `longtext` + `CHECK (json_valid(...))` として実装されています。PostgreSQL と異なり、`trilogy` / `mysql2` アダプターは Ruby の `Hash` を自動的に JSON 文字列へシリアライズしません。代わりに `Hash#to_s`（Ruby の inspect 形式: `{"key" => value}`）が使われるため、`json_valid()` チェックに違反します。

## 修正内容

- `TrashedIssue` に `attrs_json_for_copy` プライベートクラスメソッドを追加
- 実行時にアダプター名を検出し、`trilogy` または `mysql2` の場合のみ `.to_json` を明示的に呼び出す
- PostgreSQL・SQLite では従来通り `Hash` のまま渡す（動作変更なし）

## テスト

- `mysql2` アダプター時に `attributes_json` が有効な JSON 文字列として保存されることを確認
- `trilogy` アダプター時に同様の動作を確認
- その他のアダプター（PostgreSQL 等）では `Hash` のまま保存されることを確認

## 影響範囲

MariaDB / MySQL 環境のみ。PostgreSQL・SQLite には影響なし。