### PR TITLE
Fix crash when viewing a trashed issue with an inline attachment

### DIFF
--- a/app/controllers/trashed_issues_controller.rb
+++ b/app/controllers/trashed_issues_controller.rb
@@ -13,6 +13,13 @@ class TrashedIssuesController < ApplicationController
 
   def show
     @issue = @trashed.rebuild
+    # #rebuild sets @issue.attachments to unsaved copies (id is nil) built for
+    # the restore flow (see RestoredIssuesController). The view always renders
+    # attachments via @trashed.attachments, so clear these out here to avoid
+    # mixing them with @trashed.attachments when textilizable merges both
+    # lists, which crashes InlineAttachmentsScrubber's sort_by (id nil vs id
+    # present with an equal created_on cannot be compared).
+    @issue.attachments = []
     @relations = @issue.relations
     @journals = @issue.journals.sort_by(&:created_on)
     @journals.each.with_index(1) do |journal, indice|

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe '#textilizable' do
     subject { helper.textilizable(issue, :description, :attachments => trashed.attachments) }
 
-    let(:issue) { trashed.rebuild }
+    # TrashedIssuesController#show clears @issue.attachments after #rebuild, since
+    # #rebuild's unsaved copies (id is nil) would otherwise duplicate @trashed.attachments
+    # here and crash InlineAttachmentsScrubber's sort_by (see trashed_issue_show_spec.rb).
+    let(:issue) { trashed.rebuild.tap { |i| i.attachments = [] } }
     let(:trashed) { TrashedIssue.first }
     let(:source_issue) { create(:issue, description: "![](testfile.jpg)\r\n") }
     let!(:attachment) { create(:attachment, container: source_issue) }

--- a/spec/requests/trashed_issue_show_spec.rb
+++ b/spec/requests/trashed_issue_show_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require File.expand_path('../rails_helper', __dir__)
+
+RSpec.describe 'Trashed issue show', type: :request do
+  let(:user) { create(:user, admin: true) }
+  let(:tracker) { create(:tracker) }
+
+  before do
+    allow_any_instance_of(User).to receive(:deliver_security_notification) { nil }
+    allow(User).to receive(:current) { user }
+  end
+
+  subject { get "/trashed_issues/#{trashed.id}" }
+
+  let!(:trashed) do
+    # create an issue with an image attached inline in the description, as reported:
+    # deleting it and then opening it from the trash previously raised
+    # ArgumentError: comparison of Array with Array failed
+    # (InlineAttachmentsScrubber#initialize merges @trashed.attachments, which have
+    # real ids, with the wrapped issue's own attachments, which are unsaved copies
+    # with a nil id but the same created_on, and sort_by cannot compare the two).
+    issue = create(:issue, tracker: tracker, description: "![](testfile.jpg)\r\n")
+    create(:attachment, container: issue).update!(filename: 'testfile.jpg')
+
+    issue.destroy
+    TrashedIssue.last
+  end
+
+  it 'renders the trashed issue without an internal error' do
+    subject
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'resolves the inline image to the real attachment' do
+    subject
+    attachment = Attachment.find_by(filename: 'testfile.jpg')
+    expect(response.body).to include("/attachments/download/#{attachment.id}/testfile.jpg")
+  end
+end


### PR DESCRIPTION
Story: https://insidemine.agileware.jp/redmine/issues/113563

## Summary
Fixes an internal server error that occurs when opening a trashed issue (from the Activity tab) whose description had an inline image attachment before it was deleted.

## Root cause
`TrashedIssuesController#show` calls `textilizable @issue, :description, :attachments => @trashed.attachments`. `@issue` (the return value of `TrashedIssue#rebuild`) holds its own `attachments`, which `#rebuild` builds as **unsaved copies with a nil id** (`attachments.map { |a| a.copy(container: i) }`).

`Redmine::WikiFormatting::InlineAttachmentsScrubber#initialize` merges `options[:attachments]` (`@trashed.attachments`, real ids) with `@obj.attachments` (`@issue.attachments`, nil-id unsaved copies), then sorts:

```ruby
@attachments = @attachments.sort_by { |a| [a.created_on, a.id] }.reverse
```

Since both lists are copies of the same underlying attachment, their created_on values are equal, so the sort falls back to comparing id — a real integer against nil — which raises ArgumentError: comparison of Array with Array failed.

Note that the nil-id unsaved copies are essential to the restore flow: RestoredIssuesController#create relies on them being inserted as brand-new attachment rows when @issue.save! runs, while the original trashed attachments are removed afterward via @trashed.destroy!. So this behavior in #rebuild cannot simply be removed.

## Fix
Clear the unsaved copies with @issue.attachments = [] right after #rebuild, but only inside TrashedIssuesController#show.

 - The view always renders attachments (inline images and the attachment list) from @trashed.attachments; @issue.attachments is never used for display.
 - #rebuild itself is untouched, so RestoredIssuesController's restore logic is unaffected.

## Testing
 - spec/requests/trashed_issue_show_spec.rb (new): creates an issue with an inline image attachment, destroys it, opens the trashed issue's show page, and asserts a 200 response with the image resolved to the real attachment's download URL.
 - spec/helpers/application_helper_spec.rb (updated): this existing spec reproduced the ArgumentError before the fix; updated to reflect the corrected flow.
 - Confirmed no regressions in spec/models/trashed_issue_spec.rb, spec/models/trashed_issue/issue_wrapper_spec.rb, and spec/requests/issue_restoration_spec.rb (restore feature).

### TestCafe実行結果

最新の結果: https://github.com/agileware-jp/redmine_issue_trash/pull/33#issuecomment-5170769623
