### PR TITLE
Activityタブ表示時のN+1解消(TrashedIssueのproject/deleted_byをpreload)

### DIFF
--- a/app/models/trashed_issue.rb
+++ b/app/models/trashed_issue.rb
@@ -16,7 +16,7 @@ class TrashedIssue < defined?(ApplicationRecord) == 'constant' ? ApplicationReco
                 author: :deleted_by,
                 url: ->(i) { { controller: :trashed_issues, action: :show, id: i.id } },
                 type: ->(_) { 'del' } # for del-icon
-  acts_as_activity_provider scope: -> { joins(:project) }.tap { |p|
+  acts_as_activity_provider scope: -> { joins(:project).preload(:project, :deleted_by) }.tap { |p|
                                      # support proc for old Redmine
                                      %w[where visible reorder].each do |name|
                                        p.define_singleton_method name do |*args|

--- a/spec/models/trashed_issue_spec.rb
+++ b/spec/models/trashed_issue_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe TrashedIssue, type: :model do
     end
   end
 
+  describe 'activity provider scope' do
+    # Activityタブでのevent_author/project参照がN+1にならないよう、
+    # projectとdeleted_byをpreloadしていることを検証する
+    subject(:scope) { described_class.activity_provider_options['trashed_issues'][:scope].call }
+
+    it { expect(scope.preload_values).to contain_exactly(:project, :deleted_by) }
+  end
+
   describe '#attachments' do
     subject(:attachments) do
       source_issue.destroy


### PR DESCRIPTION
## 背景

Activityタブ(/activities)のパフォーマンス調査の過程で、本プラグインの`TrashedIssue`にも表示件数分のN+1クエリが発生する問題を確認した。

なお、Redmine本体側(Attachment/Document/WikiContentVersion/TimeEntry)にも同種のN+1が別途存在し、そちらはredmine.orgへpatchを提出済み([#44363](https://www.redmine.org/issues/44363))。本PRはそれとは完全に独立した別件で、本プラグイン自体のコードが原因のため、本プラグインを直接修正する。

## 確認した問題

`app/models/trashed_issue.rb`の`acts_as_activity_provider`のscopeが`joins(:project)`のみで`preload`が無く、Activityタブでイベントが表示されるたびに以下が個別クエリされる。

- `event_author` → `deleted_by`(belongs_to、未preload)
- `project` → `joins`は権限フィルタ用のSQLに過ぎず、Rubyオブジェクトとしてのpreloadはされていない

## 対応内容

scopeに`.preload(:project, :deleted_by)`を追加するのみの1行修正。挙動は変えない。

```diff
-  acts_as_activity_provider scope: -> { joins(:project) }.tap { |p|
+  acts_as_activity_provider scope: -> { joins(:project).preload(:project, :deleted_by) }.tap { |p|
```

"old Redmine"向けの互換シム(.tapブロック内でwhere/visible/reorderをprocに生やしている部分)はそのまま維持している。
 
### 補足

TrashedIssueイベントは発生頻度が低い(issue削除は日常操作に比べて稀)ため、本PR単体でのパフォーマンス改善効果は限定的。本体側([#44363](https://www.redmine.org/issues/44363))と合わせて対応することが前提。